### PR TITLE
Bump supported versions

### DIFF
--- a/persistent-postgis.cabal
+++ b/persistent-postgis.cabal
@@ -7,12 +7,12 @@ library
   hs-source-dirs:      src
   ghc-options:         -O2 -Wall -Wno-orphans
   default-language:    Haskell2010
-  build-depends:       aeson >=1.3.1 && <1.3.2
-                     , base >=4.9.0 && <4.10
-                     , bytestring >=0.10.8 && <0.11
-                     , geos >=0.2.2 && <0.3
-                     , http-api-data >=0.3.7 && <0.4
-                     , persistent >=2.8.2 && <2.9
+  build-depends:       aeson >=1.3.1 && <1.6
+                     , base >=4.9.0 && <4.15
+                     , bytestring >=0.10.8 && <0.12
+                     , geos >=0.2.2 && <0.5
+                     , http-api-data >=0.3.7 && <0.5
+                     , persistent >=2.8.2 && <2.12
                      , text >=1.2.3 && <1.3
   exposed-modules:     Data.Geometry.Geos.Instances
                      , Database.Persist.Postgis.Geography

--- a/src/Data/Geometry/Geos/Instances.hs
+++ b/src/Data/Geometry/Geos/Instances.hs
@@ -4,14 +4,14 @@ module Data.Geometry.Geos.Instances () where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Geometry.Geos.Geometry
-    ( Coordinate(Coordinate2, Coordinate3)
-    , LineString(LineString)
-    , LinearRing(LinearRing)
-    , MultiLineString(MultiLineString)
-    , MultiPoint(MultiPoint)
-    , MultiPolygon(MultiPolygon)
-    , Point(Point)
-    , Polygon(Polygon)
+    ( Coordinate
+    , LineString
+    , LinearRing
+    , MultiLineString
+    , MultiPoint
+    , MultiPolygon
+    , Point
+    , Polygon
     )
 deriving instance FromJSON Coordinate
 deriving instance FromJSON Point

--- a/src/Database/Persist/Postgis/Geography.hs
+++ b/src/Database/Persist/Postgis/Geography.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE DeriveAnyClass, DeriveGeneric, FlexibleInstances, GADTs, GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE CPP, LambdaCase, OverloadedStrings, StandaloneDeriving #-}
 
+#if MIN_VERSION_persistent(2,11,0)
+#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistLiteralEscaped
+#else
+#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistDbSpecific
+#endif
+
 module Database.Persist.Postgis.Geography
     ( Geography
         ( PointGeography
@@ -42,16 +48,10 @@ import Data.Geometry.Geos.Geometry
 import Data.Text (pack)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8Builder)
 import Database.Persist.Sql
-    ( PersistField, PersistFieldSql, PersistValue(PersistDbSpecific), SqlType(SqlOther)
+    ( PersistField, PersistFieldSql, PersistValue(PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR), SqlType(SqlOther)
     , fromPersistValue, sqlType, toPersistValue
     )
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData, parseUrlPiece, toUrlPiece)
-
-#if MIN_VERSION_persistent(2,11,0)
-#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistLiteralEscaped
-#else
-#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistDbSpecific
-#endif
 
 data Geography a where
     PointGeography :: Point -> Geography Point
@@ -278,3 +278,5 @@ instance PersistFieldSql (Geography MultiPolygon) where
 
 instance PersistFieldSql (Some Geography) where
     sqlType _ = SqlOther "geography"
+
+#undef PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR

--- a/src/Database/Persist/Postgis/Geography.hs
+++ b/src/Database/Persist/Postgis/Geography.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveAnyClass, DeriveGeneric, FlexibleInstances, GADTs, GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase, OverloadedStrings, StandaloneDeriving #-}
+{-# LANGUAGE CPP, LambdaCase, OverloadedStrings, StandaloneDeriving #-}
 
 module Database.Persist.Postgis.Geography
     ( Geography
@@ -47,6 +47,11 @@ import Database.Persist.Sql
     )
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData, parseUrlPiece, toUrlPiece)
 
+#if MIN_VERSION_persistent(2,11,0)
+#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistLiteralEscaped
+#else
+#define PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR PersistDbSpecific
+#endif
 
 data Geography a where
     PointGeography :: Point -> Geography Point
@@ -218,20 +223,20 @@ instance PersistField (Geography MultiPolygon) where
 instance PersistField (Some Geography) where
     toPersistValue (Some g) = case g of
         PointGeography p ->
-            PersistDbSpecific . writeHex $ PointGeometry p (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ PointGeometry p (Just 4326)
         LineStringGeography ls -> 
-            PersistDbSpecific . writeHex $ LineStringGeometry ls (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ LineStringGeometry ls (Just 4326)
         LinearRingGeography lr ->
-            PersistDbSpecific . writeHex $ LinearRingGeometry lr (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ LinearRingGeometry lr (Just 4326)
         PolygonGeography pl ->
-            PersistDbSpecific . writeHex $ PolygonGeometry pl (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ PolygonGeometry pl (Just 4326)
         MultiPointGeography mp ->
-            PersistDbSpecific . writeHex $ MultiPointGeometry mp (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ MultiPointGeometry mp (Just 4326)
         MultiLineStringGeography mls ->
-            PersistDbSpecific . writeHex $ MultiLineStringGeometry mls (Just 4326)
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ MultiLineStringGeometry mls (Just 4326)
         MultiPolygonGeography mpl ->
-            PersistDbSpecific . writeHex $ MultiPolygonGeometry mpl (Just 4326)
-    fromPersistValue (PersistDbSpecific b) = case readHex b of
+            PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR . writeHex $ MultiPolygonGeometry mpl (Just 4326)
+    fromPersistValue (PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR b) = case readHex b of
         Just (Some (PointGeometry p (Just 4326))) ->
             Right . Some $ PointGeography p
         Just (Some (LineStringGeometry ls (Just 4326))) ->
@@ -247,7 +252,7 @@ instance PersistField (Some Geography) where
         Just (Some (MultiPolygonGeometry mpl (Just 4326))) ->
             Right . Some $ MultiPolygonGeography mpl
         _ -> Left "Invalid Geography hex"
-    fromPersistValue _ = Left "Geography values must be converted from PersistDbSpecific"
+    fromPersistValue _ = Left "Geography values must be converted from PERSISTENT_CUSTOM_VALUE_CONSTRUCTOR"
 
 
 instance PersistFieldSql (Geography Point) where


### PR DESCRIPTION
I haven't tested this very extensively, but have tested this builds on:

* lts-16.26 + geos-0.3.0
* lts-16.26 + geos-0.3.0 + persistent-2.11.0.2
* lts-16.26 + geos-0.4.1 + persistent-2.11.0.2

Haven't tested it works at runtime yet.